### PR TITLE
Add -no-pie compiler flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = /usr/bin/gcc
-CFLAGS = -O3 -Wall -Wextra
+CFLAGS = -O3 -Wall -Wextra -no-pie
 
 ######################################################
 


### PR DESCRIPTION
Recent Linux distributions ship GCC with --enable-default-pie, which
causes the build to fail without passing -no-pie.

See also:
https://wiki.ubuntu.com/SecurityTeam/PIE